### PR TITLE
Updating Terraform w/vnet pipeline to use production provider

### DIFF
--- a/terraform-vnet/main.tf
+++ b/terraform-vnet/main.tf
@@ -122,7 +122,7 @@ resource "azurerm_spring_cloud_service" "example" {
   network {
     app_subnet_id             = azurerm_subnet.app_subnet.id
     service_runtime_subnet_id = azurerm_subnet.service_subnet.id
-    cidr                      = ["10.4.0.0/16", "10.5.0.0/16", "10.3.0.1/16"]
+    cidr_ranges               = ["10.4.0.0/16", "10.5.0.0/16", "10.3.0.1/16"]
   }
 
   tags = {

--- a/terraform-vnet/provision-resources-vnet-terraform.yml
+++ b/terraform-vnet/provision-resources-vnet-terraform.yml
@@ -24,7 +24,7 @@ pool:
 steps:
 - task: TerraformInstaller@0
   inputs:
-    terraformVersion: '0.12.3'
+    terraformVersion: '0.12.31'
 
 - task: TerraformTaskV1@0
   inputs:

--- a/terraform-vnet/provision-resources-vnet-terraform.yml
+++ b/terraform-vnet/provision-resources-vnet-terraform.yml
@@ -6,7 +6,7 @@
 name: Provision Resources
 
 variables:
-- group: azure-environment-terraform
+- group: azure-environment
 
 parameters:
 - name: location

--- a/terraform-vnet/provision-resources-vnet-terraform.yml
+++ b/terraform-vnet/provision-resources-vnet-terraform.yml
@@ -27,11 +27,12 @@ steps:
 - task: TerraformInstaller@0
   inputs:
     terraformVersion: '0.12.3'
-    
+
 - task: TerraformTaskV1@0
   inputs:
     provider: 'azurerm'
     command: 'init'
+    workingDirectory: '$(Build.Repository.LocalPath)/terraform-vnet'
     backendServiceArm: '$(SERVICE_CONNECTION_NAME)'
     backendAzureRmResourceGroupName: '$(REMOTE_BACKEND_RESOURCE_GROUP)'
     backendAzureRmStorageAccountName: '$(REMOTE_BACKEND_STORAGE_ACCOUNT)'
@@ -50,6 +51,7 @@ steps:
 - task: TerraformTaskV1@0
   inputs:
     provider: 'azurerm'
+    workingDirectory: '$(Build.Repository.LocalPath)/terraform-vnet'
     command: 'apply'
     commandOptions: '-auto-approve -var resource_group=$(RESOURCE_GROUP) -var spring_cloud_service=$(SPRING_CLOUD_NAME) -var mysql_server_admin_password=$(MYSQL_PASSWORD)'
     environmentServiceNameAzureRM: '$(SERVICE_CONNECTION_NAME)'

--- a/terraform-vnet/provision-resources-vnet-terraform.yml
+++ b/terraform-vnet/provision-resources-vnet-terraform.yml
@@ -6,7 +6,7 @@
 name: Provision Resources
 
 variables:
-- group: azure-environment
+- group: azure-environment-terraform
 
 parameters:
 - name: location
@@ -24,31 +24,6 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
-
-- task: GoTool@0
-  inputs:
-    version: '1.14.4'
-    goPath: '/gopath'
-    goBin: '/gopath/bin'
-
-
-
-- task: CmdLine@2
-  inputs:
-    script: |
-      echo Write your commands here
-      echo Cloning the Azurerm Provider with vnet support 
-            
-            sudo mkdir -p terraform
-            sudo chmod +rwx terraform
-            cd terraform
-            sudo git clone --single-branch -b spring_cloud_service_vnet_integration https://github.com/njuCZ/terraform-provider-azurerm.git
-            cd  terraform-provider-azurerm
-            sudo chmod +rwx /opt/hostedtoolcache/go/1.14.4/x64/bin/go
-            sudo make build
-            cd ../..
-            sudo cp ~/go/bin/terraform-provider-azurerm .
-
                     
 - task: TerraformTaskV1@0
   inputs:

--- a/terraform-vnet/provision-resources-vnet-terraform.yml
+++ b/terraform-vnet/provision-resources-vnet-terraform.yml
@@ -37,15 +37,6 @@ steps:
     backendAzureRmContainerName: '$(REMOTE_BACKEND_CONTAINER_NAME)'
     backendAzureRmKey: '$(REMOTE_BACKEND_STORAGE_KEY)'
 
-- task: Bash@3
-  inputs:
-    targetType: 'inline'
-    failOnStderr: false
-    script: |
-      # Write your commands here
-       echo Checking the terraform version
-       terraform -v            
-
 - task: TerraformTaskV1@0
   inputs:
     provider: 'azurerm'

--- a/terraform-vnet/provision-resources-vnet-terraform.yml
+++ b/terraform-vnet/provision-resources-vnet-terraform.yml
@@ -1,7 +1,5 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
+# Provisions an Azure Spring Cloud environment on a virtual network.
+# Note: This pipeline must be run with a Service Connection that has the Owner role on the target resource group.
 
 name: Provision Resources
 

--- a/terraform-vnet/provision-resources-vnet-terraform.yml
+++ b/terraform-vnet/provision-resources-vnet-terraform.yml
@@ -74,5 +74,5 @@ steps:
     provider: 'azurerm'
     command: 'apply'
     commandOptions: '-auto-approve -var resource_group=$(RESOURCE_GROUP) -var spring_cloud_service=$(SPRING_CLOUD_NAME) -var mysql_server_admin_password=$(MYSQL_PASSWORD)'
-    environmentServiceNameAzureRM: 'Java Petclinic Subscription'
+    environmentServiceNameAzureRM: '$(SERVICE_CONNECTION_NAME)'
 

--- a/terraform-vnet/provision-resources-vnet-terraform.yml
+++ b/terraform-vnet/provision-resources-vnet-terraform.yml
@@ -24,7 +24,10 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
-                    
+- task: TerraformInstaller@0
+  inputs:
+    terraformVersion: '0.12.3'
+    
 - task: TerraformTaskV1@0
   inputs:
     provider: 'azurerm'

--- a/terraform-vnet/provision-resources-vnet-terraform.yml
+++ b/terraform-vnet/provision-resources-vnet-terraform.yml
@@ -24,7 +24,7 @@ pool:
 steps:
 - task: TerraformInstaller@0
   inputs:
-    terraformVersion: '0.12.31'
+    terraformVersion: '0.15.1'
 
 - task: TerraformTaskV1@0
   inputs:


### PR DESCRIPTION
The Terraform w/Vnet provisioning sample does not work as is - the custom build of terraform no longer works nor is it necessary.

Also, fixed a hardcoded service connection name in the second TF task.