### PR TITLE
Remove Azure CLI deprecated warnings form Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,23 +268,23 @@ Create 5 apps.
 
 ```bash
     az spring-cloud app create --name ${API_GATEWAY} --instance-count 1 --assign-endpoint true \
-        --memory 2 \
+        --memory 2Gi \
         --jvm-options='-Xms2048m -Xmx2048m'
     
     az spring-cloud app create --name ${ADMIN_SERVER} --instance-count 1 --assign-endpoint true \
-        --memory 2 \
+        --memory 2Gi \
         --jvm-options='-Xms2048m -Xmx2048m'
     
     az spring-cloud app create --name ${CUSTOMERS_SERVICE} --instance-count 1 \
-        --memory 2 \
+        --memory 2Gi \
         --jvm-options='-Xms2048m -Xmx2048m'
     
     az spring-cloud app create --name ${VETS_SERVICE} --instance-count 1 \
-        --memory 2 \
+        --memory 2Gi \
         --jvm-options='-Xms2048m -Xmx2048m'
     
     az spring-cloud app create --name ${VISITS_SERVICE} --instance-count 1 \
-        --memory 2 \
+        --memory 2Gi \
         --jvm-options='-Xms2048m -Xmx2048m'
 ```
 

--- a/README.md
+++ b/README.md
@@ -367,17 +367,17 @@ Deploy Spring Boot applications to Azure.
 
 ```bash
     az spring-cloud app deploy --name ${API_GATEWAY} \
-        --jar-path ${API_GATEWAY_JAR} \
+        --artifact-path ${API_GATEWAY_JAR} \
         --jvm-options='-Xms2048m -Xmx2048m -Dspring.profiles.active=mysql'
     
     
     az spring-cloud app deploy --name ${ADMIN_SERVER} \
-        --jar-path ${ADMIN_SERVER_JAR} \
+        --artifact-path ${ADMIN_SERVER_JAR} \
         --jvm-options='-Xms2048m -Xmx2048m -Dspring.profiles.active=mysql'
     
     
     az spring-cloud app deploy --name ${CUSTOMERS_SERVICE} \
-        --jar-path ${CUSTOMERS_SERVICE_JAR} \
+        --artifact-path ${CUSTOMERS_SERVICE_JAR} \
         --jvm-options='-Xms2048m -Xmx2048m -Dspring.profiles.active=mysql' \
         --env MYSQL_SERVER_FULL_NAME=${MYSQL_SERVER_FULL_NAME} \
               MYSQL_DATABASE_NAME=${MYSQL_DATABASE_NAME} \
@@ -386,7 +386,7 @@ Deploy Spring Boot applications to Azure.
     
     
     az spring-cloud app deploy --name ${VETS_SERVICE} \
-        --jar-path ${VETS_SERVICE_JAR} \
+        --artifact-path ${VETS_SERVICE_JAR} \
         --jvm-options='-Xms2048m -Xmx2048m -Dspring.profiles.active=mysql' \
         --env MYSQL_SERVER_FULL_NAME=${MYSQL_SERVER_FULL_NAME} \
               MYSQL_DATABASE_NAME=${MYSQL_DATABASE_NAME} \
@@ -395,7 +395,7 @@ Deploy Spring Boot applications to Azure.
               
     
     az spring-cloud app deploy --name ${VISITS_SERVICE} \
-        --jar-path ${VISITS_SERVICE_JAR} \
+        --artifact-path ${VISITS_SERVICE_JAR} \
         --jvm-options='-Xms2048m -Xmx2048m -Dspring.profiles.active=mysql' \
         --env MYSQL_SERVER_FULL_NAME=${MYSQL_SERVER_FULL_NAME} \
               MYSQL_DATABASE_NAME=${MYSQL_DATABASE_NAME} \


### PR DESCRIPTION
Following the examples in the Readme throws deprecated warnings on some commands.