### PR TITLE
upgrade maven version to 3.8.5

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar


### PR DESCRIPTION
The Maven version in Maven Wrapper is too old, It can't support some features like  `--no-transfer-progress` etc.

Using the latest [maven buildpack](https://github.com/paketo-buildpacks/maven) to build the repo with `mvnw`, it needs the maven version higher than 3.6.1, otherwise, see [this issue](https://github.com/paketo-buildpacks/maven/issues/144)

We need to upgrade maven version timely.
