### PR TITLE
Support deploy-to-azure button for enterprise plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Let's jump in and get this up and running in Azure. When you are finished, you w
 
 ![Spring Petclinic Application](media/petclinic.jpg)
 
+Before delving into the step-by-step execution of the application, you can simply click the Deploy to Azure button. This will instantly deploy the app to Azure Spring Apps.
+
+| Deploy to Azure Spring Apps | |
+|--|--|
+| Consumption plan   |Not support|
+| Basic/Standard plan|Not support|
+| Enterprise plan    |[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2Fspring-petclinic-microservices%2Fazure%2Finfra%2Fazuredeploy.json)|
+
 ## Run with AZD
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Before delving into the step-by-step execution of the application, you can simpl
 
 | Deploy to Azure Spring Apps | |
 |--|--|
-| Consumption plan   |Not support|
-| Basic/Standard plan|Not support|
+| Consumption plan   |Not supported|
+| Basic/Standard plan|Not supported|
 | Enterprise plan    |[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2Fspring-petclinic-microservices%2Fazure%2Finfra%2Fazuredeploy.json)|
 
 ## Run with AZD

--- a/infra/azuredeploy.json
+++ b/infra/azuredeploy.json
@@ -1,0 +1,1979 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": { },
+  "variables": {
+    "$fxv#0": {
+      "analysisServicesServers": "as",
+      "apiManagementService": "apim-",
+      "appConfigurationConfigurationStores": "appcs-",
+      "appManagedEnvironments": "cae-",
+      "appContainerApps": "ca-",
+      "authorizationPolicyDefinitions": "policy-",
+      "automationAutomationAccounts": "aa-",
+      "blueprintBlueprints": "bp-",
+      "blueprintBlueprintsArtifacts": "bpa-",
+      "cacheRedis": "redis-",
+      "cdnProfiles": "cdnp-",
+      "cdnProfilesEndpoints": "cdne-",
+      "cognitiveServicesAccounts": "cog-",
+      "cognitiveServicesFormRecognizer": "cog-fr-",
+      "cognitiveServicesTextAnalytics": "cog-ta-",
+      "computeAvailabilitySets": "avail-",
+      "computeCloudServices": "cld-",
+      "computeDiskEncryptionSets": "des",
+      "computeDisks": "disk",
+      "computeDisksOs": "osdisk",
+      "computeGalleries": "gal",
+      "computeSnapshots": "snap-",
+      "computeVirtualMachines": "vm",
+      "computeVirtualMachineScaleSets": "vmss-",
+      "containerInstanceContainerGroups": "ci",
+      "containerRegistryRegistries": "cr",
+      "containerServiceManagedClusters": "aks-",
+      "databricksWorkspaces": "dbw-",
+      "dataFactoryFactories": "adf-",
+      "dataLakeAnalyticsAccounts": "dla",
+      "dataLakeStoreAccounts": "dls",
+      "dataMigrationServices": "dms-",
+      "dBforMySQLServers": "mysql-",
+      "dBforPostgreSQLServers": "psql-",
+      "devicesIotHubs": "iot-",
+      "devicesProvisioningServices": "provs-",
+      "devicesProvisioningServicesCertificates": "pcert-",
+      "documentDBDatabaseAccounts": "cosmos-",
+      "eventGridDomains": "evgd-",
+      "eventGridDomainsTopics": "evgt-",
+      "eventGridEventSubscriptions": "evgs-",
+      "eventHubNamespaces": "evhns-",
+      "eventHubNamespacesEventHubs": "evh-",
+      "hdInsightClustersHadoop": "hadoop-",
+      "hdInsightClustersHbase": "hbase-",
+      "hdInsightClustersKafka": "kafka-",
+      "hdInsightClustersMl": "mls-",
+      "hdInsightClustersSpark": "spark-",
+      "hdInsightClustersStorm": "storm-",
+      "hybridComputeMachines": "arcs-",
+      "insightsActionGroups": "ag-",
+      "insightsComponents": "appi-",
+      "keyVaultVaults": "kv-",
+      "kubernetesConnectedClusters": "arck",
+      "kustoClusters": "dec",
+      "kustoClustersDatabases": "dedb",
+      "logicIntegrationAccounts": "ia-",
+      "logicWorkflows": "logic-",
+      "machineLearningServicesWorkspaces": "mlw-",
+      "managedIdentityUserAssignedIdentities": "id-",
+      "managementManagementGroups": "mg-",
+      "migrateAssessmentProjects": "migr-",
+      "networkApplicationGateways": "agw-",
+      "networkApplicationSecurityGroups": "asg-",
+      "networkAzureFirewalls": "afw-",
+      "networkBastionHosts": "bas-",
+      "networkConnections": "con-",
+      "networkDnsZones": "dnsz-",
+      "networkExpressRouteCircuits": "erc-",
+      "networkFirewallPolicies": "afwp-",
+      "networkFirewallPoliciesWebApplication": "waf",
+      "networkFirewallPoliciesRuleGroups": "wafrg",
+      "networkFrontDoors": "fd-",
+      "networkFrontdoorWebApplicationFirewallPolicies": "fdfp-",
+      "networkLoadBalancersExternal": "lbe-",
+      "networkLoadBalancersInternal": "lbi-",
+      "networkLoadBalancersInboundNatRules": "rule-",
+      "networkLocalNetworkGateways": "lgw-",
+      "networkNatGateways": "ng-",
+      "networkNetworkInterfaces": "nic-",
+      "networkNetworkSecurityGroups": "nsg-",
+      "networkNetworkSecurityGroupsSecurityRules": "nsgsr-",
+      "networkNetworkWatchers": "nw-",
+      "networkPrivateDnsZones": "pdnsz-",
+      "networkPrivateLinkServices": "pl-",
+      "networkPublicIPAddresses": "pip-",
+      "networkPublicIPPrefixes": "ippre-",
+      "networkRouteFilters": "rf-",
+      "networkRouteTables": "rt-",
+      "networkRouteTablesRoutes": "udr-",
+      "networkTrafficManagerProfiles": "traf-",
+      "networkVirtualNetworkGateways": "vgw-",
+      "networkVirtualNetworks": "vnet-",
+      "networkVirtualNetworksSubnets": "snet-",
+      "networkVirtualNetworksVirtualNetworkPeerings": "peer-",
+      "networkVirtualWans": "vwan-",
+      "networkVpnGateways": "vpng-",
+      "networkVpnGatewaysVpnConnections": "vcn-",
+      "networkVpnGatewaysVpnSites": "vst-",
+      "notificationHubsNamespaces": "ntfns-",
+      "notificationHubsNamespacesNotificationHubs": "ntf-",
+      "operationalInsightsWorkspaces": "log-",
+      "portalDashboards": "dash-",
+      "powerBIDedicatedCapacities": "pbi-",
+      "purviewAccounts": "pview-",
+      "postgresServer": "pg-",
+      "recoveryServicesVaults": "rsv-",
+      "resourcesResourceGroups": "rg-",
+      "searchSearchServices": "srch-",
+      "serviceBusNamespaces": "sb-",
+      "serviceBusNamespacesQueues": "sbq-",
+      "serviceBusNamespacesTopics": "sbt-",
+      "serviceEndPointPolicies": "se-",
+      "serviceFabricClusters": "sf-",
+      "signalRServiceSignalR": "sigr",
+      "springApps": "asa-",
+      "sqlManagedInstances": "sqlmi-",
+      "sqlServers": "sql-",
+      "sqlServersDataWarehouse": "sqldw-",
+      "sqlServersDatabases": "sqldb-",
+      "sqlServersDatabasesStretch": "sqlstrdb-",
+      "storageStorageAccounts": "st",
+      "storageStorageAccountsVm": "stvm",
+      "storSimpleManagers": "ssimp",
+      "streamAnalyticsCluster": "asa-",
+      "synapseWorkspaces": "syn",
+      "synapseWorkspacesAnalyticsWorkspaces": "synw",
+      "synapseWorkspacesSqlPoolsDedicated": "syndp",
+      "synapseWorkspacesSqlPoolsSpark": "synsp",
+      "timeSeriesInsightsEnvironments": "tsi-",
+      "webServerFarms": "plan-",
+      "webSitesAppService": "app-",
+      "webSitesAppServiceEnvironment": "ase-",
+      "webSitesFunctions": "func-",
+      "webStaticSites": "stapp-"
+    },
+    "abbrs": "[variables('$fxv#0')]",
+    "location": "[resourceGroup().location]",
+    "resourceToken": "[toLower(uniqueString(subscription().id, resourceGroup().name, variables('location')))]",
+    "asaInstanceName": "[format('{0}{1}', variables('abbrs').springApps, variables('resourceToken'))]",
+    "adminServerAppName": "admin-server",
+    "customersServiceAppName": "customers-service",
+    "vetsServiceAppName": "vets-service",
+    "visitsServiceAppName": "visits-service",
+    "apiGatewayAppName": "api-gateway",
+    "logAnalyticsName": "[format('{0}{1}', variables('abbrs').operationalInsightsWorkspaces, variables('resourceToken'))]",
+    "applicationInsightsName": "[format('{0}{1}', variables('abbrs').insightsComponents, variables('resourceToken'))]",
+    "applicationInsightsDashboardName": "[format('{0}{1}', variables('abbrs').portalDashboards, variables('resourceToken'))]",
+    "userAssignedManagedIdentityName": "[format('{0}{1}', variables('abbrs').managedIdentityUserAssignedIdentities, variables('resourceToken'))]",
+    "const_ownerRole": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+    "const_scriptLocation": "https://github.com/Azure/azure-quickstart-templates/blob/master/quickstarts/microsoft.appplatform/microservice-apps-enterprise-plan/scripts/",
+    "const_uploadScriptName": "deploy-jar-to-asa.sh",
+    "const_checkScriptName": "check-provision-state.ps1",
+    "const_checkingBuilderStateDeploymentName": "checking-build-service-builder-state",
+    "ref_identityId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userAssignedManagedIdentityName'))]",
+    "name_deploymentScriptName": "asa-enterprise-deployment-script",
+    "name_roleAssignmentName": "[guid(format('{0}{1}Role assignment in group{0}', resourceGroup().name, variables('ref_identityId')))]",
+    "tags": {
+      "spring-cloud-azure": "true",
+      "deploy-to-azure-button": "true"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.AppPlatform/Spring",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[variables('asaInstanceName')]",
+      "location": "[variables('location')]",
+      "tags": "[variables('tags')]",
+      "sku": {
+        "name": "E0",
+        "tier": "Enterprise"
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/buildServices",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[concat(variables('asaInstanceName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ],
+      "properties": {
+        "resourceRequests": {}
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/apps",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[format('{0}/{1}', variables('asaInstanceName'), variables('adminServerAppName'))]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ],
+      "properties": {
+        "public": true,
+        "httpsOnly": false,
+        "temporaryDisk": {
+          "sizeInGB": 5,
+          "mountPath": "/tmp"
+        },
+        "persistentDisk": {
+          "sizeInGB": 0,
+          "mountPath": "/persistent"
+        },
+        "enableEndToEndTLS": false,
+        "ingressSettings": {
+          "readTimeoutInSeconds": 300,
+          "sendTimeoutInSeconds": 60,
+          "sessionCookieMaxAge": 0,
+          "sessionAffinity": "None",
+          "backendProtocol": "Default"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/apps",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[format('{0}/{1}', variables('asaInstanceName'), variables('customersServiceAppName'))]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ],
+      "properties": {
+        "httpsOnly": false,
+        "temporaryDisk": {
+          "sizeInGB": 5,
+          "mountPath": "/tmp"
+        },
+        "persistentDisk": {
+          "sizeInGB": 0,
+          "mountPath": "/persistent"
+        },
+        "enableEndToEndTLS": false,
+        "ingressSettings": {
+          "readTimeoutInSeconds": 300,
+          "sendTimeoutInSeconds": 60,
+          "sessionCookieMaxAge": 0,
+          "sessionAffinity": "None",
+          "backendProtocol": "Default"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/apps",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[format('{0}/{1}', variables('asaInstanceName'), variables('vetsServiceAppName'))]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ],
+      "properties": {
+        "httpsOnly": false,
+        "temporaryDisk": {
+          "sizeInGB": 5,
+          "mountPath": "/tmp"
+        },
+        "persistentDisk": {
+          "sizeInGB": 0,
+          "mountPath": "/persistent"
+        },
+        "enableEndToEndTLS": false,
+        "ingressSettings": {
+          "readTimeoutInSeconds": 300,
+          "sendTimeoutInSeconds": 60,
+          "sessionCookieMaxAge": 0,
+          "sessionAffinity": "None",
+          "backendProtocol": "Default"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/apps",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[format('{0}/{1}', variables('asaInstanceName'), variables('visitsServiceAppName'))]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ],
+      "properties": {
+        "httpsOnly": false,
+        "temporaryDisk": {
+          "sizeInGB": 5,
+          "mountPath": "/tmp"
+        },
+        "persistentDisk": {
+          "sizeInGB": 0,
+          "mountPath": "/persistent"
+        },
+        "enableEndToEndTLS": false,
+        "ingressSettings": {
+          "readTimeoutInSeconds": 300,
+          "sendTimeoutInSeconds": 60,
+          "sessionCookieMaxAge": 0,
+          "sessionAffinity": "None",
+          "backendProtocol": "Default"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/apps",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[format('{0}/{1}', variables('asaInstanceName'), variables('apiGatewayAppName'))]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ],
+      "properties": {
+        "public": true,
+        "httpsOnly": false,
+        "temporaryDisk": {
+          "sizeInGB": 5,
+          "mountPath": "/tmp"
+        },
+        "persistentDisk": {
+          "sizeInGB": 0,
+          "mountPath": "/persistent"
+        },
+        "enableEndToEndTLS": false,
+        "ingressSettings": {
+          "readTimeoutInSeconds": 300,
+          "sendTimeoutInSeconds": 60,
+          "sessionCookieMaxAge": 0,
+          "sessionAffinity": "None",
+          "backendProtocol": "Default"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/apps/deployments",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[format('{0}/{1}/{2}', variables('asaInstanceName'), variables('adminServerAppName'), 'default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring/apps', variables('asaInstanceName'), variables('adminServerAppName'))]"
+
+      ],
+      "properties": {
+        "active": true,
+        "deploymentSettings": {
+          "resourceRequests": {
+            "cpu": "1",
+            "memory": "2Gi"
+          }
+        },
+        "source": {
+          "type": "BuildResult",
+          "buildResultId": "<default>"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/apps/deployments",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[format('{0}/{1}/{2}', variables('asaInstanceName'), variables('customersServiceAppName'), 'default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring/apps', variables('asaInstanceName'), variables('customersServiceAppName'))]"
+      ],
+      "properties": {
+        "active": true,
+        "deploymentSettings": {
+          "resourceRequests": {
+            "cpu": "1",
+            "memory": "2Gi"
+          }
+        },
+        "source": {
+          "type": "BuildResult",
+          "buildResultId": "<default>"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/apps/deployments",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[format('{0}/{1}/{2}', variables('asaInstanceName'), variables('vetsServiceAppName'), 'default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring/apps', variables('asaInstanceName'), variables('vetsServiceAppName'))]"
+      ],
+      "properties": {
+        "active": true,
+        "deploymentSettings": {
+          "resourceRequests": {
+            "cpu": "1",
+            "memory": "2Gi"
+          }
+        },
+        "source": {
+          "type": "BuildResult",
+          "buildResultId": "<default>"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/apps/deployments",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[format('{0}/{1}/{2}', variables('asaInstanceName'), variables('visitsServiceAppName'), 'default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring/apps', variables('asaInstanceName'), variables('visitsServiceAppName'))]"
+      ],
+      "properties": {
+        "active": true,
+        "deploymentSettings": {
+          "resourceRequests": {
+            "cpu": "1",
+            "memory": "2Gi"
+          }
+        },
+        "source": {
+          "type": "BuildResult",
+          "buildResultId": "<default>"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/apps/deployments",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[format('{0}/{1}/{2}', variables('asaInstanceName'), variables('apiGatewayAppName'), 'default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring/apps', variables('asaInstanceName'), variables('apiGatewayAppName'))]"
+      ],
+      "properties": {
+        "active": true,
+        "deploymentSettings": {
+          "resourceRequests": {
+            "cpu": "1",
+            "memory": "2Gi"
+          }
+        },
+        "source": {
+          "type": "BuildResult",
+          "buildResultId": "<default>"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "name": "[variables('userAssignedManagedIdentityName')]",
+      "apiVersion": "2023-01-31",
+      "location": "[variables('location')]",
+      "tags": "[variables('tags')]"
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[variables('name_roleAssignmentName')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userAssignedManagedIdentityName'))]",
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ],
+      "properties": {
+        "roleDefinitionId": "[variables('const_ownerRole')]",
+        "principalId": "[reference(variables('ref_identityId')).principalId]",
+        "principalType": "ServicePrincipal",
+        "scope": "[resourceGroup().id]"
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deploymentScripts",
+      "apiVersion": "2020-10-01",
+      "name": "[variables('const_checkingBuilderStateDeploymentName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Authorization/roleAssignments', variables('name_roleAssignmentName'))]",
+        "[resourceId('Microsoft.AppPlatform/Spring/apps/deployments', variables('asaInstanceName'), variables('adminServerAppName'), 'default')]",
+        "[resourceId('Microsoft.AppPlatform/Spring/apps/deployments', variables('asaInstanceName'), variables('customersServiceAppName'), 'default')]",
+        "[resourceId('Microsoft.AppPlatform/Spring/apps/deployments', variables('asaInstanceName'), variables('vetsServiceAppName'), 'default')]",
+        "[resourceId('Microsoft.AppPlatform/Spring/apps/deployments', variables('asaInstanceName'), variables('visitsServiceAppName'), 'default')]",
+        "[resourceId('Microsoft.AppPlatform/Spring/apps/deployments', variables('asaInstanceName'), variables('apiGatewayAppName'), 'default')]"
+      ],
+      "kind": "AzurePowerShell",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userAssignedManagedIdentityName')))]": {}
+        }
+      },
+      "properties": {
+        "azPowerShellVersion": "9.7",
+        "primaryScriptUri": "[uri(variables('const_scriptLocation'), variables('const_checkScriptName'))]",
+        "environmentVariables": [
+          {
+            "name": "SUBSCRIPTION_ID",
+            "value": "[subscription().subscriptionId]"
+          },
+          {
+            "name": "RESOURCE_GROUP",
+            "value": "[resourceGroup().name]"
+          },
+          {
+            "name": "ASA_SERVICE_NAME",
+            "value": "[variables('asaInstanceName')]"
+          }
+        ],
+        "cleanupPreference": "OnSuccess",
+        "retentionInterval": "P1D"
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/buildservices/builders/buildpackBindings",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[concat(variables('asaInstanceName'), '/default/default/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deploymentScripts', variables('const_checkingBuilderStateDeploymentName'))]"
+      ],
+      "properties": {
+        "bindingType": "ApplicationInsights",
+        "launchProperties": {
+          "properties": {
+            "sampling_percentage": 10,
+            "connection_string": "[reference(resourceId('Microsoft.Insights/components', variables('applicationInsightsName')), '2020-02-02').ConnectionString]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2022-10-01",
+      "name": "[variables('logAnalyticsName')]",
+      "location": "[variables('location')]",
+      "tags": "[variables('tags')]",
+      "properties": {
+        "retentionInDays": 30,
+        "sku": {
+          "name": "PerGB2018"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Insights/components",
+      "apiVersion": "2020-02-02",
+      "name": "[variables('applicationInsightsName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsName'))]"
+      ],
+      "tags": "[variables('tags')]",
+      "kind": "java",
+      "properties": {
+        "Application_Type": "web",
+        "Flow_Type": "Bluefield",
+        "Request_Source": "CustomDeployment",
+        "RetentionInDays": 90,
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces',variables('logAnalyticsName'))]",
+        "IngestionMode": "Disabled",
+        "publicNetworkAccessForIngestion": "Enabled",
+        "publicNetworkAccessForQuery": "Enabled"
+      }
+    },
+    {
+      "type": "Microsoft.Portal/dashboards",
+      "apiVersion": "2020-09-01-preview",
+      "name": "[variables('applicationInsightsDashboardName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Insights/components', variables('applicationInsightsName'))]"
+      ],
+      "tags": "[variables('tags')]",
+      "properties": {
+        "lenses": [
+          {
+            "order": 0,
+            "parts": [
+              {
+                "position": {
+                  "x": 0,
+                  "y": 0,
+                  "colSpan": 2,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "id",
+                      "value": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                    },
+                    {
+                      "name": "Version",
+                      "value": "1.0"
+                    }
+                  ],
+                  "type": "Extension/AppInsightsExtension/PartType/AspNetOverviewPinnedPart",
+                  "asset": {
+                    "idInputName": "id",
+                    "type": "ApplicationInsights"
+                  },
+                  "defaultMenuItemId": "overview"
+                }
+              },
+              {
+                "position": {
+                  "x": 2,
+                  "y": 0,
+                  "colSpan": 1,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "ComponentId",
+                      "value": {
+                        "Name": "[variables('applicationInsightsDashboardName')]",
+                        "SubscriptionId": "[subscription().subscriptionId]",
+                        "ResourceGroup": "[resourceGroup().name]"
+                      }
+                    },
+                    {
+                      "name": "Version",
+                      "value": "1.0"
+                    }
+                  ],
+                  "type": "Extension/AppInsightsExtension/PartType/ProactiveDetectionAsyncPart",
+                  "asset": {
+                    "idInputName": "ComponentId",
+                    "type": "ApplicationInsights"
+                  },
+                  "defaultMenuItemId": "ProactiveDetection"
+                }
+              },
+              {
+                "position": {
+                  "x": 3,
+                  "y": 0,
+                  "colSpan": 1,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "ComponentId",
+                      "value": {
+                        "Name": "[variables('applicationInsightsDashboardName')]",
+                        "SubscriptionId": "[subscription().subscriptionId]",
+                        "ResourceGroup": "[resourceGroup().name]"
+                      }
+                    },
+                    {
+                      "name": "ResourceId",
+                      "value": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                    }
+                  ],
+                  "type": "Extension/AppInsightsExtension/PartType/QuickPulseButtonSmallPart",
+                  "asset": {
+                    "idInputName": "ComponentId",
+                    "type": "ApplicationInsights"
+                  }
+                }
+              },
+              {
+                "position": {
+                  "x": 4,
+                  "y": 0,
+                  "colSpan": 1,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "ComponentId",
+                      "value": {
+                        "Name": "[variables('applicationInsightsDashboardName')]",
+                        "SubscriptionId": "[subscription().subscriptionId]",
+                        "ResourceGroup": "[resourceGroup().name]"
+                      }
+                    },
+                    {
+                      "name": "TimeContext",
+                      "value": {
+                        "durationMs": 86400000,
+                        "endTime": null,
+                        "createdTime": "2018-05-04T01:20:33.345Z",
+                        "isInitialTime": true,
+                        "grain": 1,
+                        "useDashboardTimeRange": false
+                      }
+                    },
+                    {
+                      "name": "Version",
+                      "value": "1.0"
+                    }
+                  ],
+                  "type": "Extension/AppInsightsExtension/PartType/AvailabilityNavButtonPart",
+                  "asset": {
+                    "idInputName": "ComponentId",
+                    "type": "ApplicationInsights"
+                  }
+                }
+              },
+              {
+                "position": {
+                  "x": 5,
+                  "y": 0,
+                  "colSpan": 1,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "ComponentId",
+                      "value": {
+                        "Name": "[variables('applicationInsightsDashboardName')]",
+                        "SubscriptionId": "[subscription().subscriptionId]",
+                        "ResourceGroup": "[resourceGroup().name]"
+                      }
+                    },
+                    {
+                      "name": "TimeContext",
+                      "value": {
+                        "durationMs": 86400000,
+                        "endTime": null,
+                        "createdTime": "2018-05-08T18:47:35.237Z",
+                        "isInitialTime": true,
+                        "grain": 1,
+                        "useDashboardTimeRange": false
+                      }
+                    },
+                    {
+                      "name": "ConfigurationId",
+                      "value": "78ce933e-e864-4b05-a27b-71fd55a6afad"
+                    }
+                  ],
+                  "type": "Extension/AppInsightsExtension/PartType/AppMapButtonPart",
+                  "asset": {
+                    "idInputName": "ComponentId",
+                    "type": "ApplicationInsights"
+                  }
+                }
+              },
+              {
+                "position": {
+                  "x": 0,
+                  "y": 1,
+                  "colSpan": 3,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [],
+                  "type": "Extension/HubsExtension/PartType/MarkdownPart",
+                  "settings": {
+                    "content": {
+                      "settings": {
+                        "content": "# Usage",
+                        "title": "",
+                        "subtitle": ""
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "position": {
+                  "x": 3,
+                  "y": 1,
+                  "colSpan": 1,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "ComponentId",
+                      "value": {
+                        "Name": "[variables('applicationInsightsDashboardName')]",
+                        "SubscriptionId": "[subscription().subscriptionId]",
+                        "ResourceGroup": "[resourceGroup().name]"
+                      }
+                    },
+                    {
+                      "name": "TimeContext",
+                      "value": {
+                        "durationMs": 86400000,
+                        "endTime": null,
+                        "createdTime": "2018-05-04T01:22:35.782Z",
+                        "isInitialTime": true,
+                        "grain": 1,
+                        "useDashboardTimeRange": false
+                      }
+                    }
+                  ],
+                  "type": "Extension/AppInsightsExtension/PartType/UsageUsersOverviewPart",
+                  "asset": {
+                    "idInputName": "ComponentId",
+                    "type": "ApplicationInsights"
+                  }
+                }
+              },
+              {
+                "position": {
+                  "x": 4,
+                  "y": 1,
+                  "colSpan": 3,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [],
+                  "type": "Extension/HubsExtension/PartType/MarkdownPart",
+                  "settings": {
+                    "content": {
+                      "settings": {
+                        "content": "# Reliability",
+                        "title": "",
+                        "subtitle": ""
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "position": {
+                  "x": 7,
+                  "y": 1,
+                  "colSpan": 1,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "ResourceId",
+                      "value": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                    },
+                    {
+                      "name": "DataModel",
+                      "value": {
+                        "version": "1.0.0",
+                        "timeContext": {
+                          "durationMs": 86400000,
+                          "createdTime": "2018-05-04T23:42:40.072Z",
+                          "isInitialTime": false,
+                          "grain": 1,
+                          "useDashboardTimeRange": false
+                        }
+                      },
+                      "isOptional": true
+                    },
+                    {
+                      "name": "ConfigurationId",
+                      "value": "8a02f7bf-ac0f-40e1-afe9-f0e72cfee77f",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/AppInsightsExtension/PartType/CuratedBladeFailuresPinnedPart",
+                  "isAdapter": true,
+                  "asset": {
+                    "idInputName": "ResourceId",
+                    "type": "ApplicationInsights"
+                  },
+                  "defaultMenuItemId": "failures"
+                }
+              },
+              {
+                "position": {
+                  "x": 8,
+                  "y": 1,
+                  "colSpan": 3,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [],
+                  "type": "Extension/HubsExtension/PartType/MarkdownPart",
+                  "settings": {
+                    "content": {
+                      "settings": {
+                        "content": "# Responsiveness\r\n",
+                        "title": "",
+                        "subtitle": ""
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "position": {
+                  "x": 11,
+                  "y": 1,
+                  "colSpan": 1,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "ResourceId",
+                      "value": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                    },
+                    {
+                      "name": "DataModel",
+                      "value": {
+                        "version": "1.0.0",
+                        "timeContext": {
+                          "durationMs": 86400000,
+                          "createdTime": "2018-05-04T23:43:37.804Z",
+                          "isInitialTime": false,
+                          "grain": 1,
+                          "useDashboardTimeRange": false
+                        }
+                      },
+                      "isOptional": true
+                    },
+                    {
+                      "name": "ConfigurationId",
+                      "value": "2a8ede4f-2bee-4b9c-aed9-2db0e8a01865",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/AppInsightsExtension/PartType/CuratedBladePerformancePinnedPart",
+                  "isAdapter": true,
+                  "asset": {
+                    "idInputName": "ResourceId",
+                    "type": "ApplicationInsights"
+                  },
+                  "defaultMenuItemId": "performance"
+                }
+              },
+              {
+                "position": {
+                  "x": 12,
+                  "y": 1,
+                  "colSpan": 3,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [],
+                  "type": "Extension/HubsExtension/PartType/MarkdownPart",
+                  "settings": {
+                    "content": {
+                      "settings": {
+                        "content": "# Browser",
+                        "title": "",
+                        "subtitle": ""
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "position": {
+                  "x": 15,
+                  "y": 1,
+                  "colSpan": 1,
+                  "rowSpan": 1
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "ComponentId",
+                      "value": {
+                        "Name": "[variables('applicationInsightsDashboardName')]",
+                        "SubscriptionId": "[subscription().subscriptionId]",
+                        "ResourceGroup": "[resourceGroup().name]"
+                      }
+                    },
+                    {
+                      "name": "MetricsExplorerJsonDefinitionId",
+                      "value": "BrowserPerformanceTimelineMetrics"
+                    },
+                    {
+                      "name": "TimeContext",
+                      "value": {
+                        "durationMs": 86400000,
+                        "createdTime": "2018-05-08T12:16:27.534Z",
+                        "isInitialTime": false,
+                        "grain": 1,
+                        "useDashboardTimeRange": false
+                      }
+                    },
+                    {
+                      "name": "CurrentFilter",
+                      "value": {
+                        "eventTypes": [
+                          4,
+                          1,
+                          3,
+                          5,
+                          2,
+                          6,
+                          13
+                        ],
+                        "typeFacets": {},
+                        "isPermissive": false
+                      }
+                    },
+                    {
+                      "name": "id",
+                      "value": {
+                        "Name": "[variables('applicationInsightsDashboardName')]",
+                        "SubscriptionId": "[subscription().subscriptionId]",
+                        "ResourceGroup": "[resourceGroup().name]"
+                      }
+                    },
+                    {
+                      "name": "Version",
+                      "value": "1.0"
+                    }
+                  ],
+                  "type": "Extension/AppInsightsExtension/PartType/MetricsExplorerBladePinnedPart",
+                  "asset": {
+                    "idInputName": "ComponentId",
+                    "type": "ApplicationInsights"
+                  },
+                  "defaultMenuItemId": "browser"
+                }
+              },
+              {
+                "position": {
+                  "x": 0,
+                  "y": 2,
+                  "colSpan": 4,
+                  "rowSpan": 3
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "options",
+                      "value": {
+                        "chart": {
+                          "metrics": [
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "sessions/count",
+                              "aggregationType": 5,
+                              "namespace": "microsoft.insights/components/kusto",
+                              "metricVisualization": {
+                                "displayName": "Sessions",
+                                "color": "#47BDF5"
+                              }
+                            },
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "users/count",
+                              "aggregationType": 5,
+                              "namespace": "microsoft.insights/components/kusto",
+                              "metricVisualization": {
+                                "displayName": "Users",
+                                "color": "#7E58FF"
+                              }
+                            }
+                          ],
+                          "title": "Unique sessions and users",
+                          "visualization": {
+                            "chartType": 2,
+                            "legendVisualization": {
+                              "isVisible": true,
+                              "position": 2,
+                              "hideSubtitle": false
+                            },
+                            "axisVisualization": {
+                              "x": {
+                                "isVisible": true,
+                                "axisType": 2
+                              },
+                              "y": {
+                                "isVisible": true,
+                                "axisType": 1
+                              }
+                            }
+                          },
+                          "openBladeOnClick": {
+                            "openBlade": true,
+                            "destinationBlade": {
+                              "extensionName": "HubsExtension",
+                              "bladeName": "ResourceMenuBlade",
+                              "parameters": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]",
+                                "menuid": "segmentationUsers"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "sharedTimeRange",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+                  "settings": {}
+                }
+              },
+              {
+                "position": {
+                  "x": 4,
+                  "y": 2,
+                  "colSpan": 4,
+                  "rowSpan": 3
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "options",
+                      "value": {
+                        "chart": {
+                          "metrics": [
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "requests/failed",
+                              "aggregationType": 7,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Failed requests",
+                                "color": "#EC008C"
+                              }
+                            }
+                          ],
+                          "title": "Failed requests",
+                          "visualization": {
+                            "chartType": 3,
+                            "legendVisualization": {
+                              "isVisible": true,
+                              "position": 2,
+                              "hideSubtitle": false
+                            },
+                            "axisVisualization": {
+                              "x": {
+                                "isVisible": true,
+                                "axisType": 2
+                              },
+                              "y": {
+                                "isVisible": true,
+                                "axisType": 1
+                              }
+                            }
+                          },
+                          "openBladeOnClick": {
+                            "openBlade": true,
+                            "destinationBlade": {
+                              "extensionName": "HubsExtension",
+                              "bladeName": "ResourceMenuBlade",
+                              "parameters": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]",
+                                "menuid": "failures"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "sharedTimeRange",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+                  "settings": {}
+                }
+              },
+              {
+                "position": {
+                  "x": 8,
+                  "y": 2,
+                  "colSpan": 4,
+                  "rowSpan": 3
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "options",
+                      "value": {
+                        "chart": {
+                          "metrics": [
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "requests/duration",
+                              "aggregationType": 4,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Server response time",
+                                "color": "#00BCF2"
+                              }
+                            }
+                          ],
+                          "title": "Server response time",
+                          "visualization": {
+                            "chartType": 2,
+                            "legendVisualization": {
+                              "isVisible": true,
+                              "position": 2,
+                              "hideSubtitle": false
+                            },
+                            "axisVisualization": {
+                              "x": {
+                                "isVisible": true,
+                                "axisType": 2
+                              },
+                              "y": {
+                                "isVisible": true,
+                                "axisType": 1
+                              }
+                            }
+                          },
+                          "openBladeOnClick": {
+                            "openBlade": true,
+                            "destinationBlade": {
+                              "extensionName": "HubsExtension",
+                              "bladeName": "ResourceMenuBlade",
+                              "parameters": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]",
+                                "menuid": "performance"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "sharedTimeRange",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+                  "settings": {}
+                }
+              },
+              {
+                "position": {
+                  "x": 12,
+                  "y": 2,
+                  "colSpan": 4,
+                  "rowSpan": 3
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "options",
+                      "value": {
+                        "chart": {
+                          "metrics": [
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "browserTimings/networkDuration",
+                              "aggregationType": 4,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Page load network connect time",
+                                "color": "#7E58FF"
+                              }
+                            },
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "browserTimings/processingDuration",
+                              "aggregationType": 4,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Client processing time",
+                                "color": "#44F1C8"
+                              }
+                            },
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "browserTimings/sendDuration",
+                              "aggregationType": 4,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Send request time",
+                                "color": "#EB9371"
+                              }
+                            },
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "browserTimings/receiveDuration",
+                              "aggregationType": 4,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Receiving response time",
+                                "color": "#0672F1"
+                              }
+                            }
+                          ],
+                          "title": "Average page load time breakdown",
+                          "visualization": {
+                            "chartType": 3,
+                            "legendVisualization": {
+                              "isVisible": true,
+                              "position": 2,
+                              "hideSubtitle": false
+                            },
+                            "axisVisualization": {
+                              "x": {
+                                "isVisible": true,
+                                "axisType": 2
+                              },
+                              "y": {
+                                "isVisible": true,
+                                "axisType": 1
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "sharedTimeRange",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+                  "settings": {}
+                }
+              },
+              {
+                "position": {
+                  "x": 0,
+                  "y": 5,
+                  "colSpan": 4,
+                  "rowSpan": 3
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "options",
+                      "value": {
+                        "chart": {
+                          "metrics": [
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "availabilityResults/availabilityPercentage",
+                              "aggregationType": 4,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Availability",
+                                "color": "#47BDF5"
+                              }
+                            }
+                          ],
+                          "title": "Average availability",
+                          "visualization": {
+                            "chartType": 3,
+                            "legendVisualization": {
+                              "isVisible": true,
+                              "position": 2,
+                              "hideSubtitle": false
+                            },
+                            "axisVisualization": {
+                              "x": {
+                                "isVisible": true,
+                                "axisType": 2
+                              },
+                              "y": {
+                                "isVisible": true,
+                                "axisType": 1
+                              }
+                            }
+                          },
+                          "openBladeOnClick": {
+                            "openBlade": true,
+                            "destinationBlade": {
+                              "extensionName": "HubsExtension",
+                              "bladeName": "ResourceMenuBlade",
+                              "parameters": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]",
+                                "menuid": "availability"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "sharedTimeRange",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+                  "settings": {}
+                }
+              },
+              {
+                "position": {
+                  "x": 4,
+                  "y": 5,
+                  "colSpan": 4,
+                  "rowSpan": 3
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "options",
+                      "value": {
+                        "chart": {
+                          "metrics": [
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "exceptions/server",
+                              "aggregationType": 7,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Server exceptions",
+                                "color": "#47BDF5"
+                              }
+                            },
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "dependencies/failed",
+                              "aggregationType": 7,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Dependency failures",
+                                "color": "#7E58FF"
+                              }
+                            }
+                          ],
+                          "title": "Server exceptions and Dependency failures",
+                          "visualization": {
+                            "chartType": 2,
+                            "legendVisualization": {
+                              "isVisible": true,
+                              "position": 2,
+                              "hideSubtitle": false
+                            },
+                            "axisVisualization": {
+                              "x": {
+                                "isVisible": true,
+                                "axisType": 2
+                              },
+                              "y": {
+                                "isVisible": true,
+                                "axisType": 1
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "sharedTimeRange",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+                  "settings": {}
+                }
+              },
+              {
+                "position": {
+                  "x": 8,
+                  "y": 5,
+                  "colSpan": 4,
+                  "rowSpan": 3
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "options",
+                      "value": {
+                        "chart": {
+                          "metrics": [
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "performanceCounters/processorCpuPercentage",
+                              "aggregationType": 4,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Processor time",
+                                "color": "#47BDF5"
+                              }
+                            },
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "performanceCounters/processCpuPercentage",
+                              "aggregationType": 4,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Process CPU",
+                                "color": "#7E58FF"
+                              }
+                            }
+                          ],
+                          "title": "Average processor and process CPU utilization",
+                          "visualization": {
+                            "chartType": 2,
+                            "legendVisualization": {
+                              "isVisible": true,
+                              "position": 2,
+                              "hideSubtitle": false
+                            },
+                            "axisVisualization": {
+                              "x": {
+                                "isVisible": true,
+                                "axisType": 2
+                              },
+                              "y": {
+                                "isVisible": true,
+                                "axisType": 1
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "sharedTimeRange",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+                  "settings": {}
+                }
+              },
+              {
+                "position": {
+                  "x": 12,
+                  "y": 5,
+                  "colSpan": 4,
+                  "rowSpan": 3
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "options",
+                      "value": {
+                        "chart": {
+                          "metrics": [
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "exceptions/browser",
+                              "aggregationType": 7,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Browser exceptions",
+                                "color": "#47BDF5"
+                              }
+                            }
+                          ],
+                          "title": "Browser exceptions",
+                          "visualization": {
+                            "chartType": 2,
+                            "legendVisualization": {
+                              "isVisible": true,
+                              "position": 2,
+                              "hideSubtitle": false
+                            },
+                            "axisVisualization": {
+                              "x": {
+                                "isVisible": true,
+                                "axisType": 2
+                              },
+                              "y": {
+                                "isVisible": true,
+                                "axisType": 1
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "sharedTimeRange",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+                  "settings": {}
+                }
+              },
+              {
+                "position": {
+                  "x": 0,
+                  "y": 8,
+                  "colSpan": 4,
+                  "rowSpan": 3
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "options",
+                      "value": {
+                        "chart": {
+                          "metrics": [
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "availabilityResults/count",
+                              "aggregationType": 7,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Availability test results count",
+                                "color": "#47BDF5"
+                              }
+                            }
+                          ],
+                          "title": "Availability test results count",
+                          "visualization": {
+                            "chartType": 2,
+                            "legendVisualization": {
+                              "isVisible": true,
+                              "position": 2,
+                              "hideSubtitle": false
+                            },
+                            "axisVisualization": {
+                              "x": {
+                                "isVisible": true,
+                                "axisType": 2
+                              },
+                              "y": {
+                                "isVisible": true,
+                                "axisType": 1
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "sharedTimeRange",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+                  "settings": {}
+                }
+              },
+              {
+                "position": {
+                  "x": 4,
+                  "y": 8,
+                  "colSpan": 4,
+                  "rowSpan": 3
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "options",
+                      "value": {
+                        "chart": {
+                          "metrics": [
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "performanceCounters/processIOBytesPerSecond",
+                              "aggregationType": 4,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Process IO rate",
+                                "color": "#47BDF5"
+                              }
+                            }
+                          ],
+                          "title": "Average process I/O rate",
+                          "visualization": {
+                            "chartType": 2,
+                            "legendVisualization": {
+                              "isVisible": true,
+                              "position": 2,
+                              "hideSubtitle": false
+                            },
+                            "axisVisualization": {
+                              "x": {
+                                "isVisible": true,
+                                "axisType": 2
+                              },
+                              "y": {
+                                "isVisible": true,
+                                "axisType": 1
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "sharedTimeRange",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+                  "settings": {}
+                }
+              },
+              {
+                "position": {
+                  "x": 8,
+                  "y": 8,
+                  "colSpan": 4,
+                  "rowSpan": 3
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "options",
+                      "value": {
+                        "chart": {
+                          "metrics": [
+                            {
+                              "resourceMetadata": {
+                                "id": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/components/{2}', subscription().subscriptionId, resourceGroup().name, variables('applicationInsightsDashboardName'))]"
+                              },
+                              "name": "performanceCounters/memoryAvailableBytes",
+                              "aggregationType": 4,
+                              "namespace": "microsoft.insights/components",
+                              "metricVisualization": {
+                                "displayName": "Available memory",
+                                "color": "#47BDF5"
+                              }
+                            }
+                          ],
+                          "title": "Average available memory",
+                          "visualization": {
+                            "chartType": 2,
+                            "legendVisualization": {
+                              "isVisible": true,
+                              "position": 2,
+                              "hideSubtitle": false
+                            },
+                            "axisVisualization": {
+                              "x": {
+                                "isVisible": true,
+                                "axisType": 2
+                              },
+                              "y": {
+                                "isVisible": true,
+                                "axisType": 1
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "sharedTimeRange",
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/HubsExtension/PartType/MonitorChartPart",
+                  "settings": {}
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/monitoringSettings",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[format('{0}/{1}', variables('asaInstanceName'), 'default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]",
+        "[resourceId('Microsoft.Insights/components', variables('applicationInsightsName'))]"
+      ],
+      "properties": {
+        "traceEnabled": true,
+        "appInsightsInstrumentationKey": "[reference(resourceId('Microsoft.Insights/components', variables('applicationInsightsName')), '2020-02-02').InstrumentationKey]"
+      }
+    },
+    {
+      "type": "Microsoft.Insights/diagnosticSettings",
+      "apiVersion": "2021-05-01-preview",
+      "scope": "[format('Microsoft.AppPlatform/Spring/{0}', variables('asaInstanceName'))]",
+      "name": "monitoring",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]",
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsName'))]"
+      ],
+      "properties": {
+        "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsName'))]",
+        "logs": [
+          {
+            "category": "ApplicationConsole",
+            "enabled": true,
+            "retentionPolicy": {
+              "days": 30,
+              "enabled": false
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/applicationAccelerators",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[concat(variables('asaInstanceName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/applicationLiveViews",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[concat(variables('asaInstanceName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/configurationServices",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[concat(variables('asaInstanceName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ],
+      "properties": {
+        "settings": {
+          "gitProperty": {
+            "repositories": [
+              {
+                "name": "default",
+                "patterns": [
+                  "application",
+                  "api-gateway",
+                  "admin-server",
+                  "customers-service",
+                  "vets-service",
+                  "visits-service"
+                ],
+                "label": "master",
+                "uri": "https://github.com/Azure-Samples/spring-petclinic-microservices-config.git"
+              }
+            ]
+          }
+        },
+        "generation": "Gen1"
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/devToolPortals",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[concat(variables('asaInstanceName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ],
+      "properties": {
+        "public": false,
+        "features": {
+          "applicationAccelerator": {
+            "state": "Enabled"
+          },
+          "applicationLiveView": {
+            "state": "Enabled"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/gateways",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[concat(variables('asaInstanceName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ],
+      "sku": {
+        "name": "E0",
+        "tier": "Enterprise",
+        "capacity": 2
+      },
+      "properties": {
+        "public": false,
+        "httpsOnly": false,
+        "resourceRequests": {
+          "cpu": "1",
+          "memory": "2Gi"
+        },
+        "clientAuth": {
+          "certificateVerification": "Disabled"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/serviceRegistries",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[concat(variables('asaInstanceName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/apiPortals",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[concat(variables('asaInstanceName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring', variables('asaInstanceName'))]",
+        "[resourceId('Microsoft.AppPlatform/Spring/gateways', variables('asaInstanceName'), 'default')]"
+      ],
+      "sku": {
+        "name": "E0",
+        "tier": "Enterprise",
+        "capacity": 1
+      },
+      "properties": {
+        "public": false,
+        "httpsOnly": false,
+        "gatewayIds": [
+          "[resourceId('Microsoft.AppPlatform/Spring/gateways', variables('asaInstanceName'), 'default')]"
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.AppPlatform/Spring/buildServices/agentPools",
+      "apiVersion": "2023-05-01-preview",
+      "name": "[concat(variables('asaInstanceName'), '/default/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring/buildServices', variables('asaInstanceName'), 'default')]"
+      ],
+      "properties": {
+        "poolSize": {
+          "name": "S1"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deploymentScripts",
+      "apiVersion": "2020-10-01",
+      "name": "[variables('name_deploymentScriptName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.AppPlatform/Spring/buildservices/builders/buildpackBindings', variables('asaInstanceName'), 'default', 'default', 'default')]",
+        "[resourceId('Microsoft.Authorization/roleAssignments', variables('name_roleAssignmentName'))]"
+      ],
+      "kind": "AzureCLI",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userAssignedManagedIdentityName')))]": {}
+        }
+      },
+      "properties": {
+        "AzCliVersion": "2.41.0",
+        "primaryScriptUri": "[uri(variables('const_scriptLocation'), variables('const_uploadScriptName'))]",
+        "environmentVariables": [
+          {
+            "name": "SUBSCRIPTION_ID",
+            "value": "[subscription().subscriptionId]"
+          },
+          {
+            "name": "RESOURCE_GROUP",
+            "value": "[resourceGroup().name]"
+          },
+          {
+            "name": "ASA_SERVICE_NAME",
+            "value": "[variables('asaInstanceName')]"
+          }
+        ],
+        "cleanupPreference": "OnSuccess",
+        "retentionInterval": "P1D"
+      }
+    }
+  ],
+  "outputs": {
+    "API Gateway URL": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.AppPlatform/Spring/apps', variables('asaInstanceName'), variables('apiGatewayAppName')), '2023-05-01-preview').url]"
+    },
+    "Admin Server URL": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.AppPlatform/Spring/apps', variables('asaInstanceName'), variables('adminServerAppName')), '2023-05-01-preview').url]"
+    }
+  }
+}

--- a/infra/azuredeploy.json
+++ b/infra/azuredeploy.json
@@ -154,7 +154,6 @@
     "applicationInsightsDashboardName": "[format('{0}{1}', variables('abbrs').portalDashboards, variables('resourceToken'))]",
     "userAssignedManagedIdentityName": "[format('{0}{1}', variables('abbrs').managedIdentityUserAssignedIdentities, variables('resourceToken'))]",
     "const_ownerRole": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
-    "const_scriptLocation": "https://raw.githubusercontent.com/Azure-Samples/spring-petclinic-microservices/azure/infra/scripts/",
     "const_uploadScriptName": "deploy-jar-to-asa.sh",
     "const_checkScriptName": "check-provision-state.ps1",
     "const_checkingBuilderStateDeploymentName": "checking-build-service-builder-state",
@@ -481,7 +480,7 @@
       },
       "properties": {
         "azPowerShellVersion": "9.7",
-        "primaryScriptUri": "[uri(variables('const_scriptLocation'), variables('const_checkScriptName'))]",
+        "primaryScriptUri": "[uri(deployment().properties.templateLink.uri, concat('scripts/', variables('const_checkScriptName')))]",
         "environmentVariables": [
           {
             "name": "SUBSCRIPTION_ID",
@@ -1946,7 +1945,7 @@
       },
       "properties": {
         "AzCliVersion": "2.41.0",
-        "primaryScriptUri": "[uri(variables('const_scriptLocation'), variables('const_uploadScriptName'))]",
+        "primaryScriptUri": "[uri(deployment().properties.templateLink.uri, concat('scripts/', variables('const_uploadScriptName')))]",
         "environmentVariables": [
           {
             "name": "SUBSCRIPTION_ID",

--- a/infra/azuredeploy.json
+++ b/infra/azuredeploy.json
@@ -154,7 +154,7 @@
     "applicationInsightsDashboardName": "[format('{0}{1}', variables('abbrs').portalDashboards, variables('resourceToken'))]",
     "userAssignedManagedIdentityName": "[format('{0}{1}', variables('abbrs').managedIdentityUserAssignedIdentities, variables('resourceToken'))]",
     "const_ownerRole": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
-    "const_scriptLocation": "https://github.com/Azure/azure-quickstart-templates/blob/master/quickstarts/microsoft.appplatform/microservice-apps-enterprise-plan/scripts/",
+    "const_scriptLocation": "https://raw.githubusercontent.com/Azure-Samples/spring-petclinic-microservices/azure/infra/scripts/",
     "const_uploadScriptName": "deploy-jar-to-asa.sh",
     "const_checkScriptName": "check-provision-state.ps1",
     "const_checkingBuilderStateDeploymentName": "checking-build-service-builder-state",

--- a/infra/scripts/check-provision-state.ps1
+++ b/infra/scripts/check-provision-state.ps1
@@ -1,0 +1,46 @@
+
+[CmdLetBinding()]
+param()
+
+$subscriptionId = $env:SUBSCRIPTION_ID
+$resourceGroup = $env:RESOURCE_GROUP
+$asaServiceName = $env:ASA_SERVICE_NAME
+
+# Fail fast the deployment if envs are empty
+if (!$subscriptionId) {
+    Write-Error "The subscription Id is not successfully retrieved, please retry another deployment."
+    exit 1
+}
+if (!$resourceGroup) {
+    Write-Error "The resource group is not successfully retrieved, please retry another deployment."
+    exit 1
+}
+if (!$asaServiceName) {
+    Write-Error "The Azure Spring Apps service name is not successfully retrieved, please retry another deployment."
+    exit 1
+}
+
+$apiUrl = 'https://management.azure.com/subscriptions/' + $subscriptionId + '/resourceGroups/' + $resourceGroup + '/providers/Microsoft.AppPlatform/Spring/' + $asaServiceName + '/buildServices/default/builders/default?api-version=2023-05-01-preview'
+$state = $null
+$timeout = New-TimeSpan -Seconds 900
+Write-Output "Check the status of Build Service Builder provisioning state within $timeout ..."
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+$accessToken = (Get-AzAccessToken).Token
+$headers = @{
+    'Authorization' = 'Bearer ' + $accessToken
+}
+$Succeeded = 'Succeeded'
+while ($sw.Elapsed -lt $timeout) {
+    $response = Invoke-WebRequest -Uri $apiUrl -Headers $headers -Method GET
+    $content = $response.Content | ConvertFrom-Json
+    $state = $content.properties.provisioningState
+    if ($state -eq $Succeeded) {
+        break
+    }
+    Start-Sleep -Seconds 5
+}
+Write-Output "State: $state"
+if ($state -ne $Succeeded) {
+    Write-Error "The Build Service Builder provisioning state is not succeeded."
+    exit 1
+}

--- a/infra/scripts/deploy-jar-to-asa.sh
+++ b/infra/scripts/deploy-jar-to-asa.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+# Fail fast the deployment if envs are empty
+if [[ -z "$SUBSCRIPTION_ID" ]]; then
+  echo "The subscription Id is not successfully retrieved, please retry another deployment." >&2
+  exit 1
+fi
+
+if [[ -z "$RESOURCE_GROUP" ]]; then
+  echo "The resource group is not successfully retrieved, please retry another deployment." >&2
+  exit 1
+fi
+
+if [[ -z "$ASA_SERVICE_NAME" ]]; then
+  echo "The Azure Spring Apps service name is not successfully retrieved, please retry another deployment." >&2
+  exit 1
+fi
+
+base_url="https://github.com/Azure-Samples/spring-petclinic-microservices/releases/download"
+auth_header="no-auth"
+version="3.0.1"
+declare -a artifact_arr=("admin-server" "customers-service" "vets-service" "visits-service" "api-gateway")
+
+az extension add --name spring --upgrade
+
+for item in "${artifact_arr[@]}"
+do
+  jar_file_name="$item-$version.jar"
+  source_url="$base_url/v$version/$jar_file_name"
+  # Download binary
+  echo "Downloading binary from $source_url to $jar_file_name"
+  if [ "$auth_header" == "no-auth" ]; then
+      curl -L "$source_url" -o $jar_file_name
+  else
+      curl -H "Authorization: $auth_header" "$source_url" -o $jar_file_name
+  fi
+
+  config_file_pattern="application,$item"
+  az spring application-configuration-service bind --resource-group $RESOURCE_GROUP --service $ASA_SERVICE_NAME --app $item
+  az spring service-registry bind --resource-group $RESOURCE_GROUP --service $ASA_SERVICE_NAME --app $item
+  az spring app deploy --resource-group $RESOURCE_GROUP --service $ASA_SERVICE_NAME --name $item --artifact-path $jar_file_name --config-file-pattern $config_file_pattern
+done
+
+# Delete uami generated before exiting the script
+az identity delete --ids ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}


### PR DESCRIPTION
Sync code from https://github.com/Azure/azure-quickstart-templates/pull/13532

Try this button:
| Deploy to Azure Spring Apps | |
|--|--|
| Consumption plan   |Not supported|
| Basic/Standard plan|Not supported|
| Enterprise plan    |[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmoarychan%2Fspring-petclinic-microservices%2Fpr-demo%2Finfra%2Fazuredeploy.json)|
