### PR TITLE
Expose build information for asae app live view

### DIFF
--- a/spring-petclinic-customers-service/pom.xml
+++ b/spring-petclinic-customers-service/pom.xml
@@ -120,4 +120,24 @@
             </build>
         </profile>
     </profiles>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build-info</goal>
+            </goals>
+            <configuration>
+              <additionalProperties>
+                <spring.boot.version>${project.parent.version}</spring.boot.version>
+              </additionalProperties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/spring-petclinic-frontend/README.md
+++ b/spring-petclinic-frontend/README.md
@@ -44,4 +44,3 @@ npm run start
 
 If everything goes well, you can access the PetClinic at given location:
 * Gateway - http://localhost:8080
-* Frontend - http://localhost:3000

--- a/spring-petclinic-vets-service/pom.xml
+++ b/spring-petclinic-vets-service/pom.xml
@@ -138,4 +138,25 @@
             </build>
         </profile>
     </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build-info</goal>
+            </goals>
+            <configuration>
+              <additionalProperties>
+                <spring.boot.version>${project.parent.version}</spring.boot.version>
+              </additionalProperties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/spring-petclinic-visits-service/pom.xml
+++ b/spring-petclinic-visits-service/pom.xml
@@ -118,4 +118,25 @@
             </build>
         </profile>
     </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build-info</goal>
+            </goals>
+            <configuration>
+              <additionalProperties>
+                <spring.boot.version>${project.parent.version}</spring.boot.version>
+              </additionalProperties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Add build information for apps deployed in Azure Spring Apps enterprise plan, see more from [doc](https://learn.microsoft.com/en-us/azure/spring-apps/how-to-use-application-live-view?tabs=Portal#use-application-live-view-to-monitor-your-apps).